### PR TITLE
fix(flake.nix): Avoid deprecated `defaultApp`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,11 +20,10 @@
         pkgs = import nixpkgs { inherit config overlays system; };
       in rec {
         defaultPackage = packages.website;
-        defaultApp = apps.hakyll-site;
 
         packages = with pkgs.myHaskellPackages; { inherit ssg website; };
 
-        apps.hakyll-site = flake-utils.lib.mkApp {
+        apps.default = flake-utils.lib.mkApp {
           drv = packages.ssg;
           exePath = "/bin/hakyll-site";
         };


### PR DESCRIPTION
Resolves #30

This pull request resolves the issue with `nix run . watch` in nix version 2.8, avoiding the now-deprecated `defaultApp` keyword.

A similar fix will likely need to be done for the `defaultPackage` line used above, but it appears as for now it continues to work :D. 