### PR TITLE
fix: dotfile copying and ignoring other files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
 
           installPhase = ''
             mkdir -p "$out/dist"
-            cp -r dist/* "$out/dist"
+            cp -a dist/. "$out/dist"
           '';
         };
 

--- a/ssg/src/Main.hs
+++ b/ssg/src/Main.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Control.Monad (forM_)
+import Data.List (isPrefixOf, isSuffixOf)
 import Data.Maybe (fromMaybe)
 import Hakyll
 import qualified Data.Text as T
 import qualified Data.Text.Slugger as Slugger
+import System.FilePath (takeFileName)
 import Text.Pandoc
   ( Extension (Ext_fenced_code_attributes, Ext_footnotes, Ext_gfm_auto_identifiers, Ext_implicit_header_references, Ext_smart),
     Extensions,
@@ -28,17 +30,27 @@ siteName :: String
 siteName =
   "My Site Name"
 
+-- Default configuration: https://github.com/jaspervdj/hakyll/blob/cd74877d41f41c4fba27768f84255e797748a31a/lib/Hakyll/Core/Configuration.hs#L101-L125
 config :: Configuration
 config =
   defaultConfiguration
     { destinationDirectory = "dist"
-    , ignoreFile = const False
+    , ignoreFile = ignoreFile'
     , previewHost = "127.0.0.1"
     , previewPort = 8000
     , providerDirectory = "src"
     , storeDirectory = "ssg/_cache"
     , tmpDirectory = "ssg/_tmp"
     }
+  where
+    ignoreFile' path
+      | "."    `isPrefixOf` fileName = False
+      | "#"    `isPrefixOf` fileName = True
+      | "~"    `isSuffixOf` fileName = True
+      | ".swp" `isSuffixOf` fileName = True
+      | otherwise = False
+      where
+        fileName = takeFileName path
 
 --------------------------------------------------------------------------------
 -- BUILD

--- a/ssg/ssg.cabal
+++ b/ssg/ssg.cabal
@@ -11,6 +11,7 @@ executable hakyll-site
   hs-source-dirs:    src
   build-depends:     base >= 4.8
                    , hakyll >= 4.14
+                   , filepath >= 1.0
                    , pandoc >= 2.11
                    , slugger >= 0.1.0.1
                    , text >= 1.2 && < 1.3


### PR DESCRIPTION
Fixes https://github.com/rpearce/hakyll-nix-template/issues/23

This copies over the Hakyll `defaultConfiguration` even further, specifically the `ignoreFiles'` part, and allows for us to only include the dotfiles from this section. A use case here would be a `.well-known/` directory, as I state here: https://github.com/jaspervdj/hakyll/issues/954#issuecomment-1410055609