### PR TITLE
Editor/HLS integration: Nix Env Selector, direnv, shell.nix (closes #43)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+# Loads the flake's devShell (GHC + the site's deps + HLS/cabal/hlint/ormolu)
+# so your editor's Haskell Language Server integration "just works".
+#
+# Requires direnv (https://direnv.net) and nix-direnv
+# (https://github.com/nix-community/nix-direnv). Run `direnv allow` once in
+# this directory, then point your editor's direnv integration at the project.
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 !src/js/dist
+.direnv
 .DS_Store
 .ghc.environment.*
 _cache

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "haskell.haskell",
+    "arrterian.nix-env-selector"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "nixEnvSelector.nixFile": "${workspaceFolder}/shell.nix",
+  "nixEnvSelector.useFlakes": false,
+
+  // Use the Haskell Language Server from the Nix dev shell (put on PATH by your
+  // env loader — direnv or Nix Env Selector) instead of one the Haskell
+  // extension downloads, so HLS and its bundled hlint linter match this
+  // project's GHC and dependencies. See the README "Editor integration (HLS)".
+  "haskell.manageHLS": "PATH"
+}

--- a/README.md
+++ b/README.md
@@ -110,6 +110,39 @@ instructions](https://nixos.org/download.html).
 Once you have nix installed, follow the instructions here to get access to
 flakes: https://nixos.wiki/wiki/Flakes.
 
+### Editor integration (HLS)
+
+[Haskell Language Server](https://github.com/haskell/haskell-language-server)
+needs to run inside this project's Nix dev shell (which provides the matching
+GHC, the site's dependencies, HLS, `hlint`, and `ormolu`) to work in your
+editor. Two ways to wire that up:
+
+* **VS Code — Nix Env Selector (simplest).** Install the [Nix Env
+  Selector](https://marketplace.visualstudio.com/items?itemName=arrterian.nix-env-selector)
+  extension; this repo's `.vscode/settings.json` already points it at
+  `shell.nix` (which re-exports the flake's dev shell). No extra system tooling
+  required — this is what the bundled `.vscode/` recommends.
+* **Any editor / terminal — direnv (editor-agnostic).** Install
+  [`direnv`](https://direnv.net) and
+  [`nix-direnv`](https://github.com/nix-community/nix-direnv), then run `direnv
+  allow` in this directory. The bundled `.envrc` (`use flake`) loads the dev
+  shell in your terminal and any editor with direnv integration (Emacs `envrc`,
+  vim, etc.).
+
+Both reuse the single dev-shell definition in `flake.nix`, and HLS loads the
+Haskell project from `ssg/` automatically.
+
+This repo ships `.vscode/` defaults: on first open, VS Code recommends the
+[Haskell](https://marketplace.visualstudio.com/items?itemName=haskell.haskell)
+and [Nix Env
+Selector](https://marketplace.visualstudio.com/items?itemName=arrterian.nix-env-selector)
+extensions; `.vscode/settings.json` points Nix Env Selector at `shell.nix` and
+sets `haskell.manageHLS` to `"PATH"` so the Haskell extension uses HLS from the
+Nix dev shell rather than downloading its own. That HLS bundles **hlint**, so
+lint diagnostics and "Apply hint" code actions appear automatically — no
+separate linter needed. Add a `.hlint.yaml` at the repo root to customize the
+hlint rules.
+
 ### Cachix
 
 The `./.github/workflows/main.yml` file pushes build results to

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +52,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,14 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }:
+  # Used only by ./shell.nix, to reuse the flake's devShell from non-flake
+  # tooling (the VS Code "Nix Env Selector" extension, or a bare `nix-shell`).
+  inputs.flake-compat = {
+    url = "github:edolstra/flake-compat";
+    flake = false;
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+# shell.nix
+#
+# Bridges non-flake tooling to the flake's devShell, so there is a single
+# source of truth for the dev environment (defined in flake.nix's
+# `devShells.default`). Useful for the VS Code "Nix Env Selector" extension or
+# a bare `nix-shell`. If you use flakes directly, prefer `nix develop` — or
+# direnv via ./.envrc, which loads the same environment automatically.
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+      compat = lock.nodes.flake-compat.locked;
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${compat.rev}.tar.gz";
+      sha256 = compat.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix.default


### PR DESCRIPTION
## Summary

Closes #43. Makes **Haskell Language Server** (and its bundled **hlint**) work in-editor by exposing the flake's `devShell` to editor tooling — with a single source of truth (the dev shell defined in `flake.nix`).

Addresses @kutyel's request for a `shell.nix` so an editor picks up HLS, and adds the surrounding glue to make it turnkey.

## What's included

- **`shell.nix`** — re-exports the flake's `devShell` via `flake-compat`, for the VS Code [Nix Env Selector](https://marketplace.visualstudio.com/items?itemName=arrterian.nix-env-selector) extension (the original ask) and a bare `nix-shell`.
- **`.envrc`** (`use flake`) — the editor-agnostic / terminal path via [direnv](https://direnv.net) + [nix-direnv](https://github.com/nix-community/nix-direnv) (Emacs, vim, etc.).
- **`flake-compat`** added as an input (used only by `shell.nix`); the `outputs` signature now takes `...`.
- **`.vscode/`** — `extensions.json` recommends `haskell.haskell` + `arrterian.nix-env-selector`; `settings.json` points Nix Env Selector at `shell.nix` and sets `haskell.manageHLS: "PATH"` so the Haskell extension uses HLS from the Nix dev shell (rather than downloading its own) — so hlint diagnostics and "Apply hint" code actions appear automatically.
- **`.gitignore`** — ignore direnv's `.direnv/` cache.
- **README** — a new "Editor integration (HLS)" section documenting both paths.

## Why Nix Env Selector for the VS Code extension

For VS Code specifically it's actively maintained (last commit within the past month), needs no extra system tooling, and is exactly what #43 requested. direnv remains the editor-agnostic path via `.envrc` — its real strength is the terminal + non-VS-Code editors, independent of the (less-maintained) direnv VS Code extension.

## Verified

- `shell.nix` loads the full dev shell — GHC 9.10.3 + `hakyll-site` + HLS + cabal + hlint + ormolu
- The flake still builds after the `flake-compat` change
- `cabal v2-repl` loads `ssg/src/Main.hs` cleanly, so HLS's implicit cabal cradle handles the `ssg/` subdirectory — **no `hie.yaml` needed**

The one piece only a human can confirm is the final in-editor check (installing the extensions and seeing HLS + hlint light up), but everything it depends on is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
