### PR TITLE
HTML compressor, updatedField dates, and modular ssg reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,11 @@ you:
 * RSS & Atom XML feed generation
 * Sitemap generation
 * Code syntax highlighting customization
-* HTML output minification (drops comments and collapses insignificant
-  whitespace, leaving `<pre>`/`<textarea>`/`<script>`/`<style>` intact)
-* Friendly `updated` post dates (reformats the `updated` front-matter timestamp)
+* HTML output minification
 * ...other reasonable defaults
 
 Configure the dev server, cache & tmp directories, and more in
-`./ssg/src/Main.hs`.
+`./ssg/Hakyll/Site/Configuration.hs`.
 
 ### Deployment
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@
 
 ### hakyll
 
-All of this is custmomizable, and here are some things that are already done for
+All of this is customizable, and here are some things that are already done for
 you:
 
 * [pandoc](https://github.com/jgm/pandoc/) markdown customization to make it as
@@ -72,6 +72,9 @@ you:
 * RSS & Atom XML feed generation
 * Sitemap generation
 * Code syntax highlighting customization
+* HTML output minification (drops comments and collapses insignificant
+  whitespace, leaving `<pre>`/`<textarea>`/`<script>`/`<style>` intact)
+* Friendly `updated` post dates (reformats the `updated` front-matter timestamp)
 * ...other reasonable defaults
 
 Configure the dev server, cache & tmp directories, and more in

--- a/ssg/src/Hakyll/Site/Configuration.hs
+++ b/ssg/src/Hakyll/Site/Configuration.hs
@@ -1,0 +1,96 @@
+module Hakyll.Site.Configuration
+  ( SiteConfiguration (..)
+  , H.FeedConfiguration (..)
+  , feedConfiguration
+  , hakyllConfiguration
+  , siteConfiguration
+  , mySiteName
+  , mySiteRoot
+  , myFeedTitle
+  , myFeedDescription
+  , myFeedAuthorName
+  , myFeedAuthorEmail
+  , myFeedRoot
+  ) where
+
+--------------------------------------------------------------------------------
+
+import qualified Data.List as List
+import qualified Hakyll as H
+import qualified System.FilePath as FP
+
+--------------------------------------------------------------------------------
+-- PERSONALIZATION
+
+data SiteConfiguration = SiteConfiguration
+  { siteName :: String
+  , siteRoot :: String
+  } deriving (Show)
+
+siteConfiguration :: SiteConfiguration
+siteConfiguration =
+  SiteConfiguration
+    { siteName = "My Site Name"
+    , siteRoot = "https://my-site.com"
+    }
+
+-- https://github.com/jaspervdj/hakyll/blob/66ace430f90ec97cbb9cf278ec46aec3b457fc56/lib/Hakyll/Web/Feed.hs#L69-L81
+feedConfiguration :: H.FeedConfiguration
+feedConfiguration =
+  H.FeedConfiguration
+    { H.feedTitle = "My Feed Title"
+    , H.feedDescription = "My Site Description"
+    , H.feedAuthorName = "My Name"
+    , H.feedAuthorEmail = "me@myemail.com"
+    , H.feedRoot = "https://my-site.com"
+    }
+
+--------------------------------------------------------------------------------
+-- CONFIG
+
+-- Default configuration: https://github.com/jaspervdj/hakyll/blob/cd74877d41f41c4fba27768f84255e797748a31a/lib/Hakyll/Core/Configuration.hs#L101-L125
+hakyllConfiguration :: H.Configuration
+hakyllConfiguration =
+  H.defaultConfiguration
+    { H.destinationDirectory = "dist"
+    , H.ignoreFile = ignoreFile'
+    , H.previewHost = "127.0.0.1"
+    , H.previewPort = 8000
+    , H.providerDirectory = "src"
+    , H.storeDirectory = "ssg/_cache"
+    , H.tmpDirectory = "ssg/_tmp"
+    }
+  where
+    ignoreFile' path
+      | ".DS_Store" == fileName           = True
+      | "."    `List.isPrefixOf` fileName = False
+      | "#"    `List.isPrefixOf` fileName = True
+      | "~"    `List.isSuffixOf` fileName = True
+      | ".swp" `List.isSuffixOf` fileName = True
+      | otherwise = False
+      where
+        fileName = FP.takeFileName path
+
+--------------------------------------------------------------------------------
+-- ACCESSORS
+
+mySiteName :: String
+mySiteName = siteName siteConfiguration
+
+mySiteRoot :: String
+mySiteRoot = siteRoot siteConfiguration
+
+myFeedTitle :: String
+myFeedTitle = H.feedTitle feedConfiguration
+
+myFeedDescription :: String
+myFeedDescription = H.feedDescription feedConfiguration
+
+myFeedAuthorName :: String
+myFeedAuthorName = H.feedAuthorName feedConfiguration
+
+myFeedAuthorEmail :: String
+myFeedAuthorEmail = H.feedAuthorEmail feedConfiguration
+
+myFeedRoot :: String
+myFeedRoot = H.feedRoot feedConfiguration

--- a/ssg/src/Hakyll/Site/CustomFields.hs
+++ b/ssg/src/Hakyll/Site/CustomFields.hs
@@ -1,0 +1,38 @@
+module Hakyll.Site.CustomFields (updatedField) where
+
+--------------------------------------------------------------------------------
+
+import qualified Control.Monad as Monad
+import qualified Control.Monad.Fail as MonadFail
+import qualified Data.Maybe as Maybe
+import qualified Data.Time.Clock as DTC
+import qualified Data.Time.Format as DTF
+import qualified Hakyll as H
+
+--------------------------------------------------------------------------------
+
+-- | A date field that reads the @updated@ metadata key, parses it against a few
+-- common formats, and re-renders it with @format@. Yields no result when the
+-- key is absent or unparseable, so @$if(updated)$@ stays false.
+updatedField :: String -> String -> H.Context String
+updatedField key format = H.field key $ \i -> do
+  time <- getUpdatedUTC $ H.itemIdentifier i
+  return $ DTF.formatTime DTF.defaultTimeLocale format time
+
+--------------------------------------------------------------------------------
+
+getUpdatedUTC :: (H.MonadMetadata m, MonadFail m)
+              => H.Identifier
+              -> m DTC.UTCTime
+getUpdatedUTC id' = do
+  metadata <- H.getMetadata id'
+  let tryField k fmt = H.lookupString k metadata >>= parseTime' fmt
+  Maybe.maybe empty' return $ Monad.msum [tryField "updated" fmt | fmt <- formats]
+  where
+    empty'     = MonadFail.fail $ "getUpdatedUTC: could not parse time for " ++ show id'
+    parseTime' = DTF.parseTimeM True DTF.defaultTimeLocale
+    formats    =
+      [ "%Y-%m-%d"
+      , "%Y-%m-%dT%H:%M:%SZ"       -- Atom feed-friendly
+      , "%a, %d %b %Y %H:%M:%S UT" -- RSS feed-friendly (RFC-822)
+      ]

--- a/ssg/src/Hakyll/Site/Feed.hs
+++ b/ssg/src/Hakyll/Site/Feed.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+--------------------------------------------------------------------------------
+
+module Hakyll.Site.Feed (createRss, createAtom) where
+
+--------------------------------------------------------------------------------
+
+import qualified Data.Maybe as Maybe
+import qualified Hakyll as H
+import qualified Hakyll.Site.Configuration as HSConfig
+import qualified Hakyll.Site.CustomFields as HSCustomFields
+import qualified Hakyll.Site.Post as HSPost
+
+--------------------------------------------------------------------------------
+
+createRss :: H.Rules ()
+createRss = do
+  H.route   H.idRoute
+  H.compile compileRss
+
+createAtom :: H.Rules ()
+createAtom = do
+  H.route   H.idRoute
+  H.compile compileAtom
+
+--------------------------------------------------------------------------------
+
+compileRss :: H.Compiler (H.Item String)
+compileRss =
+  H.renderRss HSConfig.feedConfiguration rssCtx
+    =<< H.recentFirst
+    =<< H.loadAllSnapshots "posts/*" "content"
+
+compileAtom :: H.Compiler (H.Item String)
+compileAtom =
+  H.renderAtom HSConfig.feedConfiguration atomCtx
+    =<< H.recentFirst
+    =<< H.loadAllSnapshots "posts/*" "content"
+
+--------------------------------------------------------------------------------
+
+rssCtx :: H.Context String
+rssCtx =
+  HSCustomFields.updatedField "updated" "%a, %d %b %Y %H:%M:%S UT"
+    <> H.field "title" updatedTitle
+    <> HSPost.postCtx
+    <> H.bodyField "description"
+
+atomCtx :: H.Context String
+atomCtx =
+  HSCustomFields.updatedField "updated" "%Y-%m-%dT%H:%M:%SZ"
+    <> H.field "title" updatedTitle
+    <> HSPost.postCtx
+    <> H.bodyField "description"
+
+--------------------------------------------------------------------------------
+-- TITLE HELPERS
+
+-- | Escape the XML metacharacters that would otherwise produce invalid RSS/Atom
+-- feeds. The @&@ pass must run first so it does not re-escape the ampersands
+-- introduced by the other entities.
+escapeXml :: String -> String
+escapeXml =
+  H.replaceAll "\"" (const "&quot;")
+    . H.replaceAll ">" (const "&gt;")
+    . H.replaceAll "<" (const "&lt;")
+    . H.replaceAll "&" (const "&amp;")
+
+escapedTitle :: H.Metadata -> String
+escapedTitle =
+  escapeXml . safeTitle
+
+safeTitle :: H.Metadata -> String
+safeTitle =
+  Maybe.fromMaybe "no title" . H.lookupString "title"
+
+updatedTitle :: H.Item a -> H.Compiler String
+updatedTitle =
+  fmap escapedTitle . H.getMetadata . H.itemIdentifier

--- a/ssg/src/Hakyll/Site/Post.hs
+++ b/ssg/src/Hakyll/Site/Post.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+--------------------------------------------------------------------------------
+
+module Hakyll.Site.Post
+  ( postCtx
+  , titleRoute
+  ) where
+
+--------------------------------------------------------------------------------
+
+import qualified Data.Maybe as Maybe
+import qualified Data.Text as T
+import qualified Data.Text.Slugger as Slugger
+import qualified Hakyll as H
+import qualified Hakyll.Site.Configuration as HSConfig
+import qualified Hakyll.Site.CustomFields as HSCustomFields
+import qualified System.FilePath as FP
+
+--------------------------------------------------------------------------------
+
+postCtx :: H.Context String
+postCtx =
+  H.constField "root" HSConfig.mySiteRoot
+    <> H.constField "feedTitle" HSConfig.myFeedTitle
+    <> H.constField "siteName" HSConfig.mySiteName
+    <> H.dateField "date" "%Y-%m-%d"
+    <> HSCustomFields.updatedField "updated" "%Y-%m-%d"
+    <> H.defaultContext
+
+--------------------------------------------------------------------------------
+-- CUSTOM TITLES
+
+titleRoute :: H.Metadata -> H.Routes
+titleRoute =
+  H.constRoute . fileNameFromTitle
+
+fileNameFromTitle :: H.Metadata -> FP.FilePath
+fileNameFromTitle =
+  T.unpack . (`T.append` ".html") . Slugger.toSlug . T.pack . getTitleFromMeta
+
+getTitleFromMeta :: H.Metadata -> String
+getTitleFromMeta =
+  Maybe.fromMaybe "no title" . H.lookupString "title"

--- a/ssg/src/Hakyll/Site/Rules.hs
+++ b/ssg/src/Hakyll/Site/Rules.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+--------------------------------------------------------------------------------
+
+module Hakyll.Site.Rules
+  ( codeCss
+  , copy
+  , css
+  , index
+  , nojekyll
+  , posts
+  , templates
+  ) where
+
+--------------------------------------------------------------------------------
+
+import qualified Hakyll as H
+import qualified Hakyll.Site.Configuration as HSConfig
+import qualified Hakyll.Site.Post as HSPost
+import qualified Text.HTML.TagSoup.Compressor as TSCompressor
+import qualified Text.Pandoc as Pandoc
+import qualified Text.Pandoc.Highlighting as PandocHighlight
+
+--------------------------------------------------------------------------------
+
+copy :: H.Rules ()
+copy = do
+  H.route H.idRoute
+  H.compile H.copyFileCompiler
+
+css :: H.Rules ()
+css = do
+  H.route H.idRoute
+  H.compile H.compressCssCompiler
+
+templates :: H.Rules ()
+templates =
+  H.compile H.templateBodyCompiler
+
+--------------------------------------------------------------------------------
+-- INDEX
+
+index :: H.Rules ()
+index = do
+  H.route H.idRoute
+  H.compile $ do
+    loadedPosts <- H.recentFirst =<< H.loadAll "posts/*"
+
+    let indexCtx = H.listField "posts" HSPost.postCtx (return loadedPosts)
+                <> H.constField "root" HSConfig.mySiteRoot
+                <> H.constField "feedTitle" HSConfig.myFeedTitle
+                <> H.constField "siteName" HSConfig.mySiteName
+                <> H.defaultContext
+
+    H.getResourceBody
+      >>= H.applyAsTemplate indexCtx
+      >>= H.loadAndApplyTemplate "templates/default.html" indexCtx
+      >>= compressHtmlCompiler
+
+--------------------------------------------------------------------------------
+-- POSTS
+
+posts :: H.Rules ()
+posts = do
+  let ctx = H.constField "type" "article" <> HSPost.postCtx
+  H.route $ H.metadataRoute HSPost.titleRoute
+  H.compile $
+    pandocCompilerCustom
+      >>= H.saveSnapshot "content"
+      >>= H.loadAndApplyTemplate "templates/post.html" ctx
+      >>= H.loadAndApplyTemplate "templates/default.html" ctx
+      >>= compressHtmlCompiler
+
+--------------------------------------------------------------------------------
+-- ASSETS
+
+-- | Generate the syntax-highlighting stylesheet from the pandoc highlight style
+-- (so code blocks are themed with a class-based stylesheet, no inline styles).
+codeCss :: H.Rules ()
+codeCss = do
+  H.route H.idRoute
+  H.compile $
+    H.makeItem (H.compressCss (PandocHighlight.styleToCss pandocHighlightStyle))
+
+-- | Emit an empty .nojekyll so GitHub Pages serves the generated output
+-- verbatim instead of running it through Jekyll.
+nojekyll :: H.Rules ()
+nojekyll = do
+  H.route H.idRoute
+  H.compile $ H.makeItem ("" :: String)
+
+--------------------------------------------------------------------------------
+-- PANDOC
+
+pandocCompilerCustom :: H.Compiler (H.Item String)
+pandocCompilerCustom =
+  H.pandocCompilerWith pandocReaderOpts pandocWriterOpts
+
+pandocReaderOpts :: Pandoc.ReaderOptions
+pandocReaderOpts =
+  H.defaultHakyllReaderOptions
+    { Pandoc.readerExtensions = pandocExtensionsCustom
+    }
+
+pandocWriterOpts :: Pandoc.WriterOptions
+pandocWriterOpts =
+  H.defaultHakyllWriterOptions
+    { Pandoc.writerExtensions = pandocExtensionsCustom
+    , Pandoc.writerHighlightStyle = Just pandocHighlightStyle
+    }
+
+pandocExtensionsCustom :: Pandoc.Extensions
+pandocExtensionsCustom =
+  Pandoc.githubMarkdownExtensions
+    <> Pandoc.extensionsFromList
+      [ Pandoc.Ext_fenced_code_attributes
+      , Pandoc.Ext_gfm_auto_identifiers
+      , Pandoc.Ext_implicit_header_references
+      , Pandoc.Ext_smart
+      , Pandoc.Ext_footnotes
+      ]
+
+-- https://hackage.haskell.org/package/pandoc/docs/Text-Pandoc-Highlighting.html
+pandocHighlightStyle :: PandocHighlight.Style
+pandocHighlightStyle =
+  PandocHighlight.breezeDark
+
+--------------------------------------------------------------------------------
+-- HTML COMPRESSION
+
+compressHtmlCompiler :: H.Item String -> H.Compiler (H.Item String)
+compressHtmlCompiler = pure . fmap compressHtml
+
+compressHtml :: String -> String
+compressHtml = H.withTagList TSCompressor.compress

--- a/ssg/src/Hakyll/Site/Sitemap.hs
+++ b/ssg/src/Hakyll/Site/Sitemap.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+--------------------------------------------------------------------------------
+
+module Hakyll.Site.Sitemap (createSitemap) where
+
+--------------------------------------------------------------------------------
+
+import qualified Hakyll as H
+import qualified Hakyll.Site.Configuration as HSConfig
+import qualified Hakyll.Site.Post as HSPost
+
+--------------------------------------------------------------------------------
+
+createSitemap :: H.Rules ()
+createSitemap = do
+  H.route H.idRoute
+  H.compile $ do
+    posts <- H.recentFirst =<< H.loadAll "posts/*"
+
+    let sitemapCtx =
+          H.constField "root" HSConfig.mySiteRoot
+            <> H.constField "siteName" HSConfig.mySiteName
+            <> H.listField "pages" HSPost.postCtx (return posts)
+
+    H.makeItem ("" :: String)
+      >>= H.loadAndApplyTemplate "templates/sitemap.xml" sitemapCtx

--- a/ssg/src/Main.hs
+++ b/ssg/src/Main.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import Control.Monad (forM_)
+import Control.Monad (forM_, msum)
 import Data.List (isPrefixOf, isSuffixOf)
 import Data.Maybe (fromMaybe)
+import Data.Time.Clock (UTCTime)
+import Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
 import Hakyll
 import qualified Data.Text as T
 import qualified Data.Text.Slugger as Slugger
+import qualified Text.HTML.TagSoup.Compressor as Compressor
 import System.FilePath (takeFileName)
 import Text.Pandoc
   ( Extension (Ext_fenced_code_attributes, Ext_footnotes, Ext_gfm_auto_identifiers, Ext_implicit_header_references, Ext_smart),
@@ -60,6 +63,7 @@ config =
     }
   where
     ignoreFile' path
+      | ".DS_Store" == fileName      = True
       | "."    `isPrefixOf` fileName = False
       | "#"    `isPrefixOf` fileName = True
       | "~"    `isSuffixOf` fileName = True
@@ -89,7 +93,7 @@ main = hakyllWith config $ do
     compile compressCssCompiler
 
   match "posts/*" $ do
-    let ctx = constField "type" "article" <> postCtx
+    let ctx = updatedField "updated" "%Y-%m-%d" <> constField "type" "article" <> postCtx
 
     route $ metadataRoute titleRoute
     compile $
@@ -97,6 +101,7 @@ main = hakyllWith config $ do
         >>= saveSnapshot "content"
         >>= loadAndApplyTemplate "templates/post.html" ctx
         >>= loadAndApplyTemplate "templates/default.html" ctx
+        >>= compressHtmlCompiler
 
   match "index.html" $ do
     route idRoute
@@ -113,6 +118,7 @@ main = hakyllWith config $ do
       getResourceBody
         >>= applyAsTemplate indexCtx
         >>= loadAndApplyTemplate "templates/default.html" indexCtx
+        >>= compressHtmlCompiler
 
   match "templates/*" $
     compile templateBodyCompiler
@@ -158,6 +164,11 @@ makeStyle :: Style -> Compiler (Item String)
 makeStyle =
   makeItem . compressCss . styleToCss
 
+-- | Minify the final rendered HTML: drop comments and collapse insignificant
+-- whitespace (leaving <pre>/<textarea>/<script>/<style> content intact).
+compressHtmlCompiler :: Item String -> Compiler (Item String)
+compressHtmlCompiler = pure . fmap (withTagList Compressor.compress)
+
 --------------------------------------------------------------------------------
 -- CONTEXT
 
@@ -174,6 +185,26 @@ postCtx =
     <> constField "siteName" mySiteName
     <> dateField "date" "%Y-%m-%d"
     <> defaultContext
+
+-- | A date field that reads the given metadata key (e.g. @updated@), parses it
+-- against a few common formats, and re-renders it with @format@. Yields no
+-- result when the key is absent or unparseable, so @$if(updated)$@ stays false.
+updatedField :: String -> String -> Context String
+updatedField key format = field key $ \item -> do
+  metadata <- getMetadata (itemIdentifier item)
+  case parseUpdated metadata of
+    Just t  -> pure (formatTime defaultTimeLocale format t)
+    Nothing -> noResult ("no parseable " ++ key ++ " field")
+  where
+    parseUpdated :: Metadata -> Maybe UTCTime
+    parseUpdated metadata =
+      lookupString key metadata
+        >>= \raw -> msum [parseTimeM True defaultTimeLocale fmt raw | fmt <- dateFormats]
+    dateFormats =
+      [ "%Y-%m-%d"
+      , "%Y-%m-%dT%H:%M:%SZ"
+      , "%a, %d %b %Y %H:%M:%S UT"
+      ]
 
 titleCtx :: Context String
 titleCtx =

--- a/ssg/src/Main.hs
+++ b/ssg/src/Main.hs
@@ -1,307 +1,35 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import Control.Monad (forM_, msum)
-import Data.List (isPrefixOf, isSuffixOf)
-import Data.Maybe (fromMaybe)
-import Data.Time.Clock (UTCTime)
-import Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
-import Hakyll
-import qualified Data.Text as T
-import qualified Data.Text.Slugger as Slugger
-import qualified Text.HTML.TagSoup.Compressor as Compressor
-import System.FilePath (takeFileName)
-import Text.Pandoc
-  ( Extension (Ext_fenced_code_attributes, Ext_footnotes, Ext_gfm_auto_identifiers, Ext_implicit_header_references, Ext_smart),
-    Extensions,
-    ReaderOptions,
-    WriterOptions (writerHighlightStyle),
-    extensionsFromList,
-    githubMarkdownExtensions,
-    readerExtensions,
-    writerExtensions,
-  )
-import Text.Pandoc.Highlighting (Style, breezeDark, styleToCss)
+--------------------------------------------------------------------------------
+
+import qualified Hakyll as H
+import qualified Hakyll.Site.Configuration as HSConfig
+import qualified Hakyll.Site.Feed as HSFeed
+import qualified Hakyll.Site.Rules as HSRules
+import qualified Hakyll.Site.Sitemap as HSSitemap
 
 --------------------------------------------------------------------------------
--- PERSONALIZATION
-
-mySiteName :: String
-mySiteName = "My Site Name"
-
-mySiteRoot :: String
-mySiteRoot = "https://my-site.com"
-
-myFeedTitle :: String
-myFeedTitle = "My Feed Title"
-
-myFeedDescription :: String
-myFeedDescription = "My Site Description"
-
-myFeedAuthorName :: String
-myFeedAuthorName = "My Name"
-
-myFeedAuthorEmail :: String
-myFeedAuthorEmail = "me@myemail.com"
-
-myFeedRoot :: String
-myFeedRoot = mySiteRoot
-
---------------------------------------------------------------------------------
--- CONFIG
-
--- Default configuration: https://github.com/jaspervdj/hakyll/blob/cd74877d41f41c4fba27768f84255e797748a31a/lib/Hakyll/Core/Configuration.hs#L101-L125
-config :: Configuration
-config =
-  defaultConfiguration
-    { destinationDirectory = "dist"
-    , ignoreFile = ignoreFile'
-    , previewHost = "127.0.0.1"
-    , previewPort = 8000
-    , providerDirectory = "src"
-    , storeDirectory = "ssg/_cache"
-    , tmpDirectory = "ssg/_tmp"
-    }
-  where
-    ignoreFile' path
-      | ".DS_Store" == fileName      = True
-      | "."    `isPrefixOf` fileName = False
-      | "#"    `isPrefixOf` fileName = True
-      | "~"    `isSuffixOf` fileName = True
-      | ".swp" `isSuffixOf` fileName = True
-      | otherwise = False
-      where
-        fileName = takeFileName path
-
---------------------------------------------------------------------------------
--- BUILD
 
 main :: IO ()
-main = hakyllWith config $ do
-  forM_
-    [ "favicon.ico"
-    , "robots.txt"
-    , "images/*"
-    , "js/*"
-    , "fonts/*"
-    ]
-    $ \f -> match f $ do
-      route idRoute
-      compile copyFileCompiler
+main = H.hakyllWith HSConfig.hakyllConfiguration $ do
+  -- COPY FILES
+  H.match "favicon.ico" HSRules.copy
+  H.match "robots.txt"  HSRules.copy
+  H.match "images/*"    HSRules.copy
+  H.match "js/*"        HSRules.copy
+  H.match "fonts/*"     HSRules.copy
 
-  match "css/*" $ do
-    route idRoute
-    compile compressCssCompiler
+  -- BUILD CSS
+  H.match "css/*" HSRules.css
 
-  match "posts/*" $ do
-    let ctx = updatedField "updated" "%Y-%m-%d" <> constField "type" "article" <> postCtx
+  -- BUILD PAGES
+  H.match "templates/*" HSRules.templates
+  H.match "posts/*"     HSRules.posts
+  H.match "index.html"  HSRules.index
 
-    route $ metadataRoute titleRoute
-    compile $
-      pandocCompilerCustom
-        >>= saveSnapshot "content"
-        >>= loadAndApplyTemplate "templates/post.html" ctx
-        >>= loadAndApplyTemplate "templates/default.html" ctx
-        >>= compressHtmlCompiler
-
-  match "index.html" $ do
-    route idRoute
-    compile $ do
-      posts <- recentFirst =<< loadAll "posts/*"
-
-      let indexCtx =
-            listField "posts" postCtx (return posts)
-              <> constField "root" mySiteRoot
-              <> constField "feedTitle" myFeedTitle
-              <> constField "siteName" mySiteName
-              <> defaultContext
-
-      getResourceBody
-        >>= applyAsTemplate indexCtx
-        >>= loadAndApplyTemplate "templates/default.html" indexCtx
-        >>= compressHtmlCompiler
-
-  match "templates/*" $
-    compile templateBodyCompiler
-
-  create ["sitemap.xml"] $ do
-    route idRoute
-    compile $ do
-      posts <- recentFirst =<< loadAll "posts/*"
-
-      let pages = posts
-          sitemapCtx =
-            constField "root" mySiteRoot
-              <> constField "siteName" mySiteName
-              <> listField "pages" postCtx (return pages)
-
-      makeItem ("" :: String)
-        >>= loadAndApplyTemplate "templates/sitemap.xml" sitemapCtx
-
-  create ["rss.xml"] $ do
-    route idRoute
-    compile (feedCompiler renderRss)
-
-  create ["atom.xml"] $ do
-    route idRoute
-    compile (feedCompiler renderAtom)
-
-  create ["css/code.css"] $ do
-    route idRoute
-    compile (makeStyle pandocHighlightStyle)
-
-  -- Emit an empty .nojekyll so GitHub Pages serves the generated output
-  -- verbatim instead of running it through Jekyll (which would drop paths
-  -- beginning with an underscore). Generated via `create` rather than copied
-  -- from a source file, as Hakyll's provider does not reliably match dotfiles.
-  create [".nojekyll"] $ do
-    route idRoute
-    compile $ makeItem ("" :: String)
-
---------------------------------------------------------------------------------
--- COMPILER HELPERS
-
-makeStyle :: Style -> Compiler (Item String)
-makeStyle =
-  makeItem . compressCss . styleToCss
-
--- | Minify the final rendered HTML: drop comments and collapse insignificant
--- whitespace (leaving <pre>/<textarea>/<script>/<style> content intact).
-compressHtmlCompiler :: Item String -> Compiler (Item String)
-compressHtmlCompiler = pure . fmap (withTagList Compressor.compress)
-
---------------------------------------------------------------------------------
--- CONTEXT
-
-feedCtx :: Context String
-feedCtx =
-  titleCtx
-    <> postCtx
-    <> bodyField "description"
-
-postCtx :: Context String
-postCtx =
-  constField "root" mySiteRoot
-    <> constField "feedTitle" myFeedTitle
-    <> constField "siteName" mySiteName
-    <> dateField "date" "%Y-%m-%d"
-    <> defaultContext
-
--- | A date field that reads the given metadata key (e.g. @updated@), parses it
--- against a few common formats, and re-renders it with @format@. Yields no
--- result when the key is absent or unparseable, so @$if(updated)$@ stays false.
-updatedField :: String -> String -> Context String
-updatedField key format = field key $ \item -> do
-  metadata <- getMetadata (itemIdentifier item)
-  case parseUpdated metadata of
-    Just t  -> pure (formatTime defaultTimeLocale format t)
-    Nothing -> noResult ("no parseable " ++ key ++ " field")
-  where
-    parseUpdated :: Metadata -> Maybe UTCTime
-    parseUpdated metadata =
-      lookupString key metadata
-        >>= \raw -> msum [parseTimeM True defaultTimeLocale fmt raw | fmt <- dateFormats]
-    dateFormats =
-      [ "%Y-%m-%d"
-      , "%Y-%m-%dT%H:%M:%SZ"
-      , "%a, %d %b %Y %H:%M:%S UT"
-      ]
-
-titleCtx :: Context String
-titleCtx =
-  field "title" updatedTitle
-
---------------------------------------------------------------------------------
--- TITLE HELPERS
-
--- | Escape the XML metacharacters that would otherwise produce invalid
--- RSS/Atom feeds. The @&@ pass must run first so it does not re-escape the
--- ampersands introduced by the other entities.
-escapeXml :: String -> String
-escapeXml =
-  replaceAll "\"" (const "&quot;")
-    . replaceAll ">" (const "&gt;")
-    . replaceAll "<" (const "&lt;")
-    . replaceAll "&" (const "&amp;")
-
-escapedTitle :: Metadata -> String
-escapedTitle =
-  escapeXml . safeTitle
-
-safeTitle :: Metadata -> String
-safeTitle =
-  fromMaybe "no title" . lookupString "title"
-
-updatedTitle :: Item a -> Compiler String
-updatedTitle =
-  fmap escapedTitle . getMetadata . itemIdentifier
-
---------------------------------------------------------------------------------
--- PANDOC
-
-pandocCompilerCustom :: Compiler (Item String)
-pandocCompilerCustom =
-  pandocCompilerWith pandocReaderOpts pandocWriterOpts
-
-pandocExtensionsCustom :: Extensions
-pandocExtensionsCustom =
-  githubMarkdownExtensions
-    <> extensionsFromList
-      [ Ext_fenced_code_attributes
-      , Ext_gfm_auto_identifiers
-      , Ext_implicit_header_references
-      , Ext_smart
-      , Ext_footnotes
-      ]
-
-pandocReaderOpts :: ReaderOptions
-pandocReaderOpts =
-  defaultHakyllReaderOptions
-    { readerExtensions = pandocExtensionsCustom
-    }
-
-pandocWriterOpts :: WriterOptions
-pandocWriterOpts =
-  defaultHakyllWriterOptions
-    { writerExtensions = pandocExtensionsCustom
-    , writerHighlightStyle = Just pandocHighlightStyle
-    }
-
-pandocHighlightStyle :: Style
-pandocHighlightStyle =
-  breezeDark -- https://hackage.haskell.org/package/pandoc/docs/Text-Pandoc-Highlighting.html
-
---------------------------------------------------------------------------------
--- FEEDS
-
-type FeedRenderer =
-  FeedConfiguration ->
-  Context String ->
-  [Item String] ->
-  Compiler (Item String)
-
-feedCompiler :: FeedRenderer -> Compiler (Item String)
-feedCompiler renderer =
-  renderer feedConfiguration feedCtx
-    =<< recentFirst
-    =<< loadAllSnapshots "posts/*" "content"
-
-feedConfiguration :: FeedConfiguration
-feedConfiguration =
-  FeedConfiguration
-    { feedTitle = myFeedTitle
-    , feedDescription = myFeedDescription
-    , feedAuthorName = myFeedAuthorName
-    , feedAuthorEmail = myFeedAuthorEmail
-    , feedRoot = myFeedRoot
-    }
-
---------------------------------------------------------------------------------
--- CUSTOM ROUTE
-
-fileNameFromTitle :: Metadata -> FilePath
-fileNameFromTitle =
-  T.unpack . (`T.append` ".html") . Slugger.toSlug . T.pack . safeTitle
-
-titleRoute :: Metadata -> Routes
-titleRoute =
-  constRoute . fileNameFromTitle
+  -- BUILD META
+  H.create ["sitemap.xml"]  HSSitemap.createSitemap
+  H.create ["rss.xml"]      HSFeed.createRss
+  H.create ["atom.xml"]     HSFeed.createAtom
+  H.create ["css/code.css"] HSRules.codeCss
+  H.create [".nojekyll"]    HSRules.nojekyll

--- a/ssg/src/Text/HTML/TagSoup/Compressor.hs
+++ b/ssg/src/Text/HTML/TagSoup/Compressor.hs
@@ -28,38 +28,45 @@ __Examples__ (with @parse = 'TS.parseTags'@ and @render = 'TS.renderTags'@):
 compress :: [TS.Tag String] -> [TS.Tag String]
 compress = go Set.empty
   where
+    -- Fold over the tag stream while carrying a `Set` of the element names we
+    -- are currently "inside", so we know when a text node's whitespace is
+    -- significant (see `insideSignificant`) and must be preserved.
     go :: Set.Set String -> [TS.Tag String] -> [TS.Tag String]
     go stack =
       \case
         [] -> []
 
-        -- Drop HTML comments: skip the tag and continue.
+        -- Remove an HTML comment by *not* prepending the tag and, instead,
+        -- continuing on with the rest of the tags.
         (TS.TagComment _ : rest) ->
           go stack rest
 
-        -- Track which elements we are currently inside by pushing the
-        -- (lower-cased) name on open...
+        -- On an open tag, like `<div>`, prepend it and continue, pushing its
+        -- (lower-cased) name onto the stack of elements we are inside.
         (tag@(TS.TagOpen name _) : rest) ->
           tag : go (Set.insert (lower name) stack) rest
 
-        -- ...and popping it back off on close.
+        -- On a closing tag, like `</div>`, prepend it and continue, popping its
+        -- name back off the stack.
         (tag@(TS.TagClose name) : rest) ->
           tag : go (Set.delete (lower name) stack) rest
 
-        -- Leave text inside whitespace-sensitive elements alone; collapse
-        -- insignificant whitespace everywhere else.
+        -- On a text node: if it sits inside a whitespace-sensitive element,
+        -- prepend it unchanged; otherwise, clean up its whitespace first.
         (tag@(TS.TagText _) : rest)
           | insideSignificant stack -> tag : go stack rest
           | otherwise               -> fmap cleanWhitespace tag : go stack rest
 
-        -- Anything else passes through unchanged.
+        -- Anything else is unexpected, so prepend it without change.
         (tag : rest) ->
           tag : go stack rest
 
     lower :: String -> String
     lower = map toLower
 
-    -- Elements whose whitespace-significant content must be preserved verbatim.
+    -- Elements whose whitespace is significant and must be preserved verbatim.
+    -- `script`/`style` matter too: collapsing newlines inside inline JS can
+    -- swallow a `//` line comment or change automatic-semicolon-insertion.
     insideSignificant :: Set.Set String -> Bool
     insideSignificant stack =
       any (`Set.member` stack) [ "pre", "script", "style", "textarea" ]
@@ -68,8 +75,14 @@ compress = go Set.empty
     cleanWhitespace " " = " "
     cleanWhitespace str = cleanSurroundingWhitespace str (cleanHtmlWhitespace str)
       where
-        -- Space, form feed, newline, carriage return, vertical tab. (Kept
-        -- narrow on purpose so non-breaking spaces etc. survive.)
+        -- The whitespace we treat as insignificant:
+        --   ' '  (space)
+        --   '\f' (form feed)
+        --   '\n' (newline / line feed)
+        --   '\r' (carriage return)
+        --   '\v' (vertical tab)
+        -- Deliberately narrower than `Data.Char.isSpace` so non-breaking spaces
+        -- and similar are left alone.
         isSpaceOrNewLineIsh :: Char -> Bool
         isSpaceOrNewLineIsh = (`elem` (" \f\n\r\v" :: String))
 
@@ -77,15 +90,18 @@ compress = go Set.empty
         cleanHtmlWhitespace :: String -> String
         cleanHtmlWhitespace = unwords . words'
           where
+            -- Like `words`, but splitting on `isSpaceOrNewLineIsh` rather than
+            -- `isSpace`, so we don't drop the whitespace we mean to keep.
+            -- https://hackage.haskell.org/package/base/docs/src/Data.OldList.html#words
             words' :: String -> [String]
             words' s = case dropWhile isSpaceOrNewLineIsh s of
               "" -> []
               s' -> w : words' s''
                 where (w, s'') = break isSpaceOrNewLineIsh s'
 
-        -- Re-add a single leading/trailing space when the original text had
-        -- surrounding whitespace, so adjacent inline elements do not run
-        -- together (e.g. @<a>x</a> <b>y</b>@).
+        -- After trimming, re-add a single leading/trailing space when the
+        -- original text had surrounding whitespace, so adjacent inline elements
+        -- do not run together (e.g. @<a>x</a> <b>y</b>@).
         cleanSurroundingWhitespace :: String -> String -> String
         cleanSurroundingWhitespace _ "" = ""
         cleanSurroundingWhitespace original trimmed =

--- a/ssg/src/Text/HTML/TagSoup/Compressor.hs
+++ b/ssg/src/Text/HTML/TagSoup/Compressor.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Text.HTML.TagSoup.Compressor (compress) where
+
+--------------------------------------------------------------------------------
+import           Data.Char (toLower)
+import qualified Data.Set as Set
+import qualified Text.HTML.TagSoup as TS
+
+--------------------------------------------------------------------------------
+{- | Compress a stream of TagSoup tags by dropping HTML comments and collapsing
+     runs of insignificant whitespace. The contents of whitespace-sensitive
+     elements (@pre@, @textarea@, @script@, @style@) are left untouched.
+
+__Examples__ (with @parse = 'TS.parseTags'@ and @render = 'TS.renderTags'@):
+
+@
+> render . compress . parse $ "<p>  hello   world  </p>"
+"<p> hello world </p>"
+
+> render . compress . parse $ "<pre>  keep\\n  me  </pre>"
+"<pre>  keep\\n  me  </pre>"
+
+> render . compress . parse $ "<p>a</p><!-- gone --><p>b</p>"
+"<p>a</p><p>b</p>"
+@
+-}
+compress :: [TS.Tag String] -> [TS.Tag String]
+compress = go Set.empty
+  where
+    go :: Set.Set String -> [TS.Tag String] -> [TS.Tag String]
+    go stack =
+      \case
+        [] -> []
+
+        -- Drop HTML comments: skip the tag and continue.
+        (TS.TagComment _ : rest) ->
+          go stack rest
+
+        -- Track which elements we are currently inside by pushing the
+        -- (lower-cased) name on open...
+        (tag@(TS.TagOpen name _) : rest) ->
+          tag : go (Set.insert (lower name) stack) rest
+
+        -- ...and popping it back off on close.
+        (tag@(TS.TagClose name) : rest) ->
+          tag : go (Set.delete (lower name) stack) rest
+
+        -- Leave text inside whitespace-sensitive elements alone; collapse
+        -- insignificant whitespace everywhere else.
+        (tag@(TS.TagText _) : rest)
+          | insideSignificant stack -> tag : go stack rest
+          | otherwise               -> fmap cleanWhitespace tag : go stack rest
+
+        -- Anything else passes through unchanged.
+        (tag : rest) ->
+          tag : go stack rest
+
+    lower :: String -> String
+    lower = map toLower
+
+    -- Elements whose whitespace-significant content must be preserved verbatim.
+    insideSignificant :: Set.Set String -> Bool
+    insideSignificant stack =
+      any (`Set.member` stack) [ "pre", "script", "style", "textarea" ]
+
+    cleanWhitespace :: String -> String
+    cleanWhitespace " " = " "
+    cleanWhitespace str = cleanSurroundingWhitespace str (cleanHtmlWhitespace str)
+      where
+        -- Space, form feed, newline, carriage return, vertical tab. (Kept
+        -- narrow on purpose so non-breaking spaces etc. survive.)
+        isSpaceOrNewLineIsh :: Char -> Bool
+        isSpaceOrNewLineIsh = (`elem` (" \f\n\r\v" :: String))
+
+        -- Collapse internal runs of whitespace down to single spaces.
+        cleanHtmlWhitespace :: String -> String
+        cleanHtmlWhitespace = unwords . words'
+          where
+            words' :: String -> [String]
+            words' s = case dropWhile isSpaceOrNewLineIsh s of
+              "" -> []
+              s' -> w : words' s''
+                where (w, s'') = break isSpaceOrNewLineIsh s'
+
+        -- Re-add a single leading/trailing space when the original text had
+        -- surrounding whitespace, so adjacent inline elements do not run
+        -- together (e.g. @<a>x</a> <b>y</b>@).
+        cleanSurroundingWhitespace :: String -> String -> String
+        cleanSurroundingWhitespace _ "" = ""
+        cleanSurroundingWhitespace original trimmed =
+          spaceWhen startsWithSpace ++ trimmed ++ spaceWhen endsWithSpace
+          where
+            spaceWhen p = if p then " " else ""
+            startsWithSpace = case original of
+              (c : _) -> isSpaceOrNewLineIsh c
+              _       -> False
+            endsWithSpace = case reverse original of
+              (c : _) -> isSpaceOrNewLineIsh c
+              _       -> False

--- a/ssg/ssg.cabal
+++ b/ssg/ssg.cabal
@@ -10,12 +10,16 @@ executable hakyll-site
   default-language:  Haskell2010
   main-is:           Main.hs
   hs-source-dirs:    src
+  other-modules:     Text.HTML.TagSoup.Compressor
   build-depends:     base >= 4.17 && < 5
+                   , containers >= 0.6
                    , hakyll >= 4.16 && < 4.18
                    , filepath >= 1.0
                    , pandoc >= 3.1 && < 3.8
                    , slugger >= 0.1.0.2
+                   , tagsoup >= 0.14
                    , text >= 1 && < 3
+                   , time >= 1.9
   ghc-options:     -Wall
                    -Wcompat
                    -Widentities

--- a/ssg/ssg.cabal
+++ b/ssg/ssg.cabal
@@ -10,7 +10,13 @@ executable hakyll-site
   default-language:  Haskell2010
   main-is:           Main.hs
   hs-source-dirs:    src
-  other-modules:     Text.HTML.TagSoup.Compressor
+  other-modules:     Hakyll.Site.Configuration
+                   , Hakyll.Site.CustomFields
+                   , Hakyll.Site.Feed
+                   , Hakyll.Site.Post
+                   , Hakyll.Site.Rules
+                   , Hakyll.Site.Sitemap
+                   , Text.HTML.TagSoup.Compressor
   build-depends:     base >= 4.17 && < 5
                    , containers >= 0.6
                    , hakyll >= 4.16 && < 4.18


### PR DESCRIPTION
## Summary

Backports improvements from [robertwpearce.com](https://github.com/rpearce/robertwpearce.com) (a real site built from this template) — an HTML compressor, friendlier `updated` dates, a `.DS_Store` ignore fix — and **reorganizes `ssg` into modules** mirroring that site's layout. Genericized to the template's placeholder defaults; verified with `nix build`.

Closes https://github.com/rpearce/hakyll-nix-template/issues/40

## Features

**HTML compressor (`Text.HTML.TagSoup.Compressor`)** — minifies output (drops comments, collapses insignificant whitespace) while leaving `<pre>`/`<textarea>`/`<script>`/`<style>` intact and keeping single spaces between inline elements. Wired into the post + index pipelines (not feeds/sitemap). Improved over the source: also protects `<script>`/`<style>`, lower-cases tag names, real Haddock examples.

**`updatedField`** — parses the `updated` metadata and renders it with a format string. The template already shipped `updated:` frontmatter + `$if(updated)$`, but rendered the raw ISO timestamp; posts now show a friendly date.

**Ignore `.DS_Store`** — the old dotfile rule let macOS Finder droppings become provider files.

## Reorganization

Splits the monolithic `Main.hs` (~310 lines) into the same module layout robertwpearce.com uses, so the template models the structure a growing site actually wants:

```
Main.hs                          -- thin rule wiring (~35 lines)
Hakyll/Site/Configuration.hs     -- SiteConfiguration/FeedConfiguration + Hakyll config + my* accessors
Hakyll/Site/CustomFields.hs      -- updatedField
Hakyll/Site/Post.hs              -- postCtx + slug route
Hakyll/Site/Feed.hs              -- RSS/Atom contexts + compilers + escapeXml
Hakyll/Site/Rules.hs             -- copy/css/index/posts/codeCss/nojekyll + pandoc + compress
Hakyll/Site/Sitemap.hs           -- sitemap
Text/HTML/TagSoup/Compressor.hs
```

The template keeps its own defaults (breezeDark highlighting via `css/code.css`, the generated `.nojekyll`, placeholder personalization). Note: matching the structure moved `updatedField` into `postCtx` + dedicated RSS/Atom contexts, so the sitemap `<lastmod>` and feed dates now derive from the `updated` metadata and are formatted per output (previously the sitemap emitted a raw ISO string). Both sample posts already carry `updated`.

## Docs

README "### hakyll" features list now mentions HTML minification and the `updated` dates (+ a `custmomizable` → `customizable` typo fix).

## Verified (`nix build`)

- Posts/index minified; code blocks preserved
- `updated` renders `2020-09-22`; sitemap + RSS/Atom valid
- All pages, feeds, sitemap, `code.css`, and `.nojekyll` generate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
