### PR TITLE
Content-hashed asset cache-busting (closes #41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ you:
 * Sitemap generation
 * Code syntax highlighting customization
 * HTML output minification
+* Content-hashed asset cache-busting (assets get a `?v=<hash>` query string so
+  browsers refetch only when a file's contents change)
 * ...other reasonable defaults
 
 Configure the dev server, cache & tmp directories, and more in
-`./ssg/Hakyll/Site/Configuration.hs`.
+`./ssg/src/Hakyll/Site/Configuration.hs`.
 
 ### Deployment
 

--- a/ssg/src/Hakyll/Site/Assets.hs
+++ b/ssg/src/Hakyll/Site/Assets.hs
@@ -1,0 +1,157 @@
+module Hakyll.Site.Assets
+  ( Manifest
+  , buildManifest
+  , versionAssetsCompiler
+  ) where
+
+--------------------------------------------------------------------------------
+
+import qualified Control.Monad as Monad
+import           Data.Bits (xor, (.&.))
+import qualified Data.ByteString as BS
+import           Data.List (dropWhileEnd, isPrefixOf, stripPrefix)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import           Data.Word (Word64)
+import qualified Hakyll as H
+import           Numeric (showHex)
+import qualified System.Directory as Dir
+import           System.FilePath (makeRelative, (</>))
+import qualified Text.HTML.TagSoup as TS
+
+--------------------------------------------------------------------------------
+
+-- | A map from an output asset path (e.g. @css/default.css@) to a short,
+-- content-derived token used for cache-busting query strings.
+type Manifest = Map.Map FilePath String
+
+--------------------------------------------------------------------------------
+
+-- | Build a `Manifest` by fingerprinting the site's static assets. Source
+-- assets are read from the given provider directory (the @css@, @js@, @images@,
+-- and @fonts@ subdirectories, plus @favicon.ico@); @generated@ carries assets
+-- Hakyll produces at build time (e.g. the highlight stylesheet) as
+-- @(outputPath, content)@ pairs so they can be fingerprinted too.
+--
+-- Source files are hashed as-is. That's a deterministic preimage of the served
+-- bytes (e.g. @css@ is compressed on the way out), so a source change still
+-- moves the token even though the token isn't a hash of the exact shipped file.
+-- The manifest is a build-time snapshot: under @hakyll-site watch@ you must
+-- restart to pick up an edited asset's new hash.
+buildManifest :: FilePath -> [(FilePath, String)] -> IO Manifest
+buildManifest providerDir generated = do
+  dirHashes <- concat <$> mapM hashDir [ "css", "js", "images", "fonts" ]
+  favHashes <- hashFile "favicon.ico"
+  let genHashes = [ (key, contentHash (TE.encodeUtf8 (T.pack content))) | (key, content) <- generated ]
+  pure $ Map.fromList (dirHashes ++ favHashes ++ genHashes)
+  where
+    -- Hash every file under `providerDir/sub`, keyed by its path relative to
+    -- the provider directory (i.e. its eventual output path). Missing
+    -- directories are simply skipped.
+    hashDir sub = do
+      let dir = providerDir </> sub
+      exists <- Dir.doesDirectoryExist dir
+      if not exists
+        then pure []
+        else do
+          files <- filesRecursive dir
+          mapM (\f -> ((,) (makeRelative providerDir f) . contentHash) <$> BS.readFile f) files
+
+    hashFile rel = do
+      let f = providerDir </> rel
+      exists <- Dir.doesFileExist f
+      if not exists
+        then pure []
+        else (\bytes -> [ (rel, contentHash bytes) ]) <$> BS.readFile f
+
+filesRecursive :: FilePath -> IO [FilePath]
+filesRecursive dir = do
+  entries <- Dir.listDirectory dir
+  fmap concat . Monad.forM entries $ \entry -> do
+    let path = dir </> entry
+    -- Skip symlinks entirely: a symlinked directory could form a cycle and hang
+    -- the build, and symlinked assets are vanishingly rare in an asset tree.
+    isSymlink <- Dir.pathIsSymbolicLink path
+    if isSymlink
+      then pure []
+      else do
+        isDir <- Dir.doesDirectoryExist path
+        if isDir then filesRecursive path else pure [ path ]
+
+--------------------------------------------------------------------------------
+
+-- | A compiler step that rewrites rendered HTML to cache-bust asset URLs. It
+-- appends @?v=<hash>@ to every @href@/@src@ pointing at an asset in the
+-- `Manifest`, and to the @content@ of @og:image@/@twitter:image@ tags. Because
+-- it runs on the final page it covers CSS/JS from templates, images from post
+-- content, and social-card images alike, with no per-asset template plumbing.
+--
+-- The site @root@ is passed so absolute social-image URLs can be matched — and
+-- rebuilt cleanly, so a stray @./@ in the @image@ metadata (which would produce
+-- e.g. @https://site.com./images/x@) can't corrupt them.
+versionAssetsCompiler :: String -> Manifest -> H.Item String -> H.Compiler (H.Item String)
+versionAssetsCompiler root manifest =
+  pure . fmap (H.withTagList (versionAssets root manifest))
+
+versionAssets :: String -> Manifest -> [TS.Tag String] -> [TS.Tag String]
+versionAssets root manifest = map versionTag
+  where
+    versionTag (TS.TagOpen name attrs)
+      | isImageMeta attrs = TS.TagOpen name (map versionContent attrs)
+      | otherwise         = TS.TagOpen name (map versionLink attrs)
+    versionTag tag = tag
+
+    -- og:image / twitter:image carry the asset URL in their @content@ attribute.
+    -- Matched by both @property@ and @name@, since Open Graph uses @property@
+    -- while Twitter's canonical markup uses @name@.
+    isImageMeta attrs =
+      any (`elem` [ "og:image", "twitter:image" ])
+        [ v | k <- [ "property", "name" ], Just v <- [ lookup k attrs ] ]
+
+    -- Page links (@href@/@src@): keep the reference as written, append the
+    -- token. Only these two attributes are handled — not @srcset@, @<source>@,
+    -- @poster@, or CSS @url(...)@.
+    versionLink (key, value)
+      | key `elem` [ "href", "src" ]
+      , Just (_, token) <- lookupAsset value = (key, value ++ "?v=" ++ token)
+      | otherwise                            = (key, value)
+
+    -- Social images: rebuild as a clean absolute URL, then append the token.
+    versionContent (key, value)
+      | key == "content"
+      , Just (path, token) <- lookupAsset value = (key, absolute path ++ "?v=" ++ token)
+      | otherwise                               = (key, value)
+
+    -- @root@ joined to a manifest path, tolerating a trailing slash on a
+    -- user-edited @siteRoot@ (so @".../"@ doesn't yield a @//@).
+    absolute path = dropWhileEnd (== '/') root ++ "/" ++ path
+
+    -- The manifest key a URL refers to (paired with its token), if any.
+    -- External or unknown URLs return Nothing and are left untouched.
+    lookupAsset :: String -> Maybe (FilePath, String)
+    lookupAsset url =
+      let path = toKey url
+      in (,) path <$> Map.lookup path manifest
+
+    -- Reduce a reference to its manifest key, tolerating a leading site root, a
+    -- @./@ prefix, and leading slashes. Does not split a @?query@/@#fragment@,
+    -- so a pre-parameterised URL simply won't match and is left as-is.
+    toKey = dropWhile (== '/') . dropDotSlash . stripRoot
+    stripRoot s    = fromMaybe s (stripPrefix root s)
+    dropDotSlash s = if "./" `isPrefixOf` s then drop 2 s else s
+
+--------------------------------------------------------------------------------
+
+-- | A short, deterministic content fingerprint (FNV-1a, low 32 bits as hex).
+-- Deliberately not `Data.Hashable`, whose salted hash changes between runs and
+-- would bust every cache on every build.
+contentHash :: BS.ByteString -> String
+contentHash bytes =
+  pad 8 (showHex (fnv1a bytes .&. 0xffffffff) "")
+  where
+    pad n s   = replicate (n - length s) '0' ++ s
+    fnv1a     = BS.foldl' (\h b -> (h `xor` fromIntegral b) * fnvPrime) fnvOffset
+    fnvOffset = 14695981039346656037 :: Word64
+    fnvPrime  = 1099511628211        :: Word64

--- a/ssg/src/Hakyll/Site/Assets.hs
+++ b/ssg/src/Hakyll/Site/Assets.hs
@@ -31,7 +31,8 @@ type Manifest = Map.Map FilePath String
 
 -- | Build a `Manifest` by fingerprinting the site's static assets. Source
 -- assets are read from the given provider directory (the @css@, @js@, @images@,
--- and @fonts@ subdirectories, plus @favicon.ico@); @generated@ carries assets
+-- @fonts@, and @pdfs@ subdirectories, plus @favicon.ico@; missing directories
+-- are skipped); @generated@ carries assets
 -- Hakyll produces at build time (e.g. the highlight stylesheet) as
 -- @(outputPath, content)@ pairs so they can be fingerprinted too.
 --
@@ -42,7 +43,7 @@ type Manifest = Map.Map FilePath String
 -- restart to pick up an edited asset's new hash.
 buildManifest :: FilePath -> [(FilePath, String)] -> IO Manifest
 buildManifest providerDir generated = do
-  dirHashes <- concat <$> mapM hashDir [ "css", "js", "images", "fonts" ]
+  dirHashes <- concat <$> mapM hashDir [ "css", "js", "images", "fonts", "pdfs" ]
   favHashes <- hashFile "favicon.ico"
   let genHashes = [ (key, contentHash (TE.encodeUtf8 (T.pack content))) | (key, content) <- generated ]
   pure $ Map.fromList (dirHashes ++ favHashes ++ genHashes)

--- a/ssg/src/Hakyll/Site/Configuration.hs
+++ b/ssg/src/Hakyll/Site/Configuration.hs
@@ -77,8 +77,11 @@ hakyllConfiguration =
 mySiteName :: String
 mySiteName = siteName siteConfiguration
 
+-- | The site root with any trailing slash removed, so joins like @$root$$url$@
+-- (og:url, canonical links) can't produce a double slash if a forker writes
+-- @siteRoot@ with a trailing @/@.
 mySiteRoot :: String
-mySiteRoot = siteRoot siteConfiguration
+mySiteRoot = List.dropWhileEnd (== '/') (siteRoot siteConfiguration)
 
 myFeedTitle :: String
 myFeedTitle = H.feedTitle feedConfiguration

--- a/ssg/src/Hakyll/Site/Rules.hs
+++ b/ssg/src/Hakyll/Site/Rules.hs
@@ -4,6 +4,7 @@
 
 module Hakyll.Site.Rules
   ( codeCss
+  , codeCssContent
   , copy
   , css
   , index
@@ -15,6 +16,7 @@ module Hakyll.Site.Rules
 --------------------------------------------------------------------------------
 
 import qualified Hakyll as H
+import qualified Hakyll.Site.Assets as HSAssets
 import qualified Hakyll.Site.Configuration as HSConfig
 import qualified Hakyll.Site.Post as HSPost
 import qualified Text.HTML.TagSoup.Compressor as TSCompressor
@@ -40,8 +42,8 @@ templates =
 --------------------------------------------------------------------------------
 -- INDEX
 
-index :: H.Rules ()
-index = do
+index :: HSAssets.Manifest -> H.Rules ()
+index manifest = do
   H.route H.idRoute
   H.compile $ do
     loadedPosts <- H.recentFirst =<< H.loadAll "posts/*"
@@ -55,13 +57,14 @@ index = do
     H.getResourceBody
       >>= H.applyAsTemplate indexCtx
       >>= H.loadAndApplyTemplate "templates/default.html" indexCtx
+      >>= HSAssets.versionAssetsCompiler HSConfig.mySiteRoot manifest
       >>= compressHtmlCompiler
 
 --------------------------------------------------------------------------------
 -- POSTS
 
-posts :: H.Rules ()
-posts = do
+posts :: HSAssets.Manifest -> H.Rules ()
+posts manifest = do
   let ctx = H.constField "type" "article" <> HSPost.postCtx
   H.route $ H.metadataRoute HSPost.titleRoute
   H.compile $
@@ -69,18 +72,24 @@ posts = do
       >>= H.saveSnapshot "content"
       >>= H.loadAndApplyTemplate "templates/post.html" ctx
       >>= H.loadAndApplyTemplate "templates/default.html" ctx
+      >>= HSAssets.versionAssetsCompiler HSConfig.mySiteRoot manifest
       >>= compressHtmlCompiler
 
 --------------------------------------------------------------------------------
 -- ASSETS
+
+-- | The generated syntax-highlighting stylesheet, as a string. Exposed so the
+-- asset manifest can fingerprint it alongside the source assets.
+codeCssContent :: String
+codeCssContent =
+  H.compressCss (PandocHighlight.styleToCss pandocHighlightStyle)
 
 -- | Generate the syntax-highlighting stylesheet from the pandoc highlight style
 -- (so code blocks are themed with a class-based stylesheet, no inline styles).
 codeCss :: H.Rules ()
 codeCss = do
   H.route H.idRoute
-  H.compile $
-    H.makeItem (H.compressCss (PandocHighlight.styleToCss pandocHighlightStyle))
+  H.compile $ H.makeItem codeCssContent
 
 -- | Emit an empty .nojekyll so GitHub Pages serves the generated output
 -- verbatim instead of running it through Jekyll.

--- a/ssg/src/Main.hs
+++ b/ssg/src/Main.hs
@@ -3,6 +3,7 @@
 --------------------------------------------------------------------------------
 
 import qualified Hakyll as H
+import qualified Hakyll.Site.Assets as HSAssets
 import qualified Hakyll.Site.Configuration as HSConfig
 import qualified Hakyll.Site.Feed as HSFeed
 import qualified Hakyll.Site.Rules as HSRules
@@ -11,25 +12,33 @@ import qualified Hakyll.Site.Sitemap as HSSitemap
 --------------------------------------------------------------------------------
 
 main :: IO ()
-main = H.hakyllWith HSConfig.hakyllConfiguration $ do
-  -- COPY FILES
-  H.match "favicon.ico" HSRules.copy
-  H.match "robots.txt"  HSRules.copy
-  H.match "images/*"    HSRules.copy
-  H.match "js/*"        HSRules.copy
-  H.match "fonts/*"     HSRules.copy
+main = do
+  -- Fingerprint the static assets up front so rendered pages can cache-bust
+  -- their URLs with `?v=<hash>` (see Hakyll.Site.Assets).
+  manifest <-
+    HSAssets.buildManifest
+      (H.providerDirectory HSConfig.hakyllConfiguration)
+      [ ("css/code.css", HSRules.codeCssContent) ]
 
-  -- BUILD CSS
-  H.match "css/*" HSRules.css
+  H.hakyllWith HSConfig.hakyllConfiguration $ do
+    -- COPY FILES
+    H.match "favicon.ico" HSRules.copy
+    H.match "robots.txt"  HSRules.copy
+    H.match "images/*"    HSRules.copy
+    H.match "js/*"        HSRules.copy
+    H.match "fonts/*"     HSRules.copy
 
-  -- BUILD PAGES
-  H.match "templates/*" HSRules.templates
-  H.match "posts/*"     HSRules.posts
-  H.match "index.html"  HSRules.index
+    -- BUILD CSS
+    H.match "css/*" HSRules.css
 
-  -- BUILD META
-  H.create ["sitemap.xml"]  HSSitemap.createSitemap
-  H.create ["rss.xml"]      HSFeed.createRss
-  H.create ["atom.xml"]     HSFeed.createAtom
-  H.create ["css/code.css"] HSRules.codeCss
-  H.create [".nojekyll"]    HSRules.nojekyll
+    -- BUILD PAGES
+    H.match "templates/*" HSRules.templates
+    H.match "posts/*"     (HSRules.posts manifest)
+    H.match "index.html"  (HSRules.index manifest)
+
+    -- BUILD META
+    H.create ["sitemap.xml"]  HSSitemap.createSitemap
+    H.create ["rss.xml"]      HSFeed.createRss
+    H.create ["atom.xml"]     HSFeed.createAtom
+    H.create ["css/code.css"] HSRules.codeCss
+    H.create [".nojekyll"]    HSRules.nojekyll

--- a/ssg/ssg.cabal
+++ b/ssg/ssg.cabal
@@ -10,7 +10,8 @@ executable hakyll-site
   default-language:  Haskell2010
   main-is:           Main.hs
   hs-source-dirs:    src
-  other-modules:     Hakyll.Site.Configuration
+  other-modules:     Hakyll.Site.Assets
+                   , Hakyll.Site.Configuration
                    , Hakyll.Site.CustomFields
                    , Hakyll.Site.Feed
                    , Hakyll.Site.Post
@@ -18,7 +19,9 @@ executable hakyll-site
                    , Hakyll.Site.Sitemap
                    , Text.HTML.TagSoup.Compressor
   build-depends:     base >= 4.17 && < 5
+                   , bytestring >= 0.11
                    , containers >= 0.6
+                   , directory >= 1.3
                    , hakyll >= 4.16 && < 4.18
                    , filepath >= 1.0
                    , pandoc >= 3.1 && < 3.8


### PR DESCRIPTION
## Summary

Closes #41 — **content-hashed asset cache-busting**. Fingerprints static assets and appends `?v=<hash>` to their URLs in the rendered HTML, so browsers refetch a file only when its contents change. Plus a couple of trailing-slash-root robustness fixes surfaced by review.

Verified with `nix build` and an expert Haskell review (which reproduced the hash + URL logic in GHC).

## How it works

- New `Hakyll.Site.Assets`: builds a manifest (`assetPath → short FNV-1a content hash`) from the `css`/`js`/`images`/`fonts` source dirs + `favicon.ico` + the generated `code.css`, and a `versionAssetsCompiler` that rewrites URLs on the final page.
- Applied to the **post and index** pipelines (not feeds/sitemap). Because it runs on rendered HTML, it versions **CSS/JS from templates, images from post content, and `og:image`/`twitter:image` social-card images** alike — no per-asset template plumbing.
- Hashes are **content-derived, per-file** (only the changed file's URL busts) and **deterministic** across builds (FNV-1a, deliberately not the salted `Data.Hashable`, which would bust every cache on every build).

## Trailing-slash-root robustness (from review)

- The social-card rewrite builds a **clean absolute URL**, fixing a pre-existing bug where `$root$$image$` with a `./` image path produced `https://site.com./images/...`.
- `mySiteRoot` now strips a trailing slash, so a forker writing `siteRoot = "https://site.com/"` no longer double-slashes `og:url` / `canonical` / `og:image`.

## Example output

```html
<link rel="stylesheet" href="./css/default.css?v=d0d42abe">
<script defer src="./js/script.js?v=7ec23118"></script>
<img src="./images/waiheke-stony-batter.jpg?v=23395255">
<meta property="og:image" content="https://my-site.com/images/robert-pearce-...jpg?v=d220609f">
```

## Verified

- css/js/images/favicon/code.css + og:image get `?v=<hash>`; feeds/sitemap untouched
- Editing one asset moves only its hash; reverting restores it
- Clean at both default and trailing-slash roots; no `-Wall` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
